### PR TITLE
True false operators for Maybe<T>

### DIFF
--- a/Application/iSynaptic.Commons/Maybe.cs
+++ b/Application/iSynaptic.Commons/Maybe.cs
@@ -208,11 +208,14 @@ namespace iSynaptic.Commons
 			throw new NotImplementedException();
     	}
 
-		public static implicit operator bool(Maybe<T> value)
+		public static Maybe<T> operator |(Maybe<T> self, Maybe<T> other)
 		{
-			return value.HasValue;
+			return self.HasValue ? self : other;
 		}
     }
+
+	public static class MaybeOperators
+	{}
 
     public static class Maybe
     {

--- a/Application/iSynaptic.Commons/Maybe.cs
+++ b/Application/iSynaptic.Commons/Maybe.cs
@@ -197,6 +197,16 @@ namespace iSynaptic.Commons
         {
             return new Maybe<T>();
         }
+
+		public static bool operator true(Maybe<T> self)
+		{
+    		return self.HasValue;
+		}
+
+    	public static bool operator false(Maybe<T> self)
+    	{
+			throw new NotImplementedException();
+    	}
     }
 
     public static class Maybe

--- a/Application/iSynaptic.Commons/Maybe.cs
+++ b/Application/iSynaptic.Commons/Maybe.cs
@@ -205,7 +205,7 @@ namespace iSynaptic.Commons
 
     	public static bool operator false(Maybe<T> self)
     	{
-			throw new NotImplementedException();
+			throw new NotImplementedException("Only used for & operator, which isn't implemented");
     	}
 
 		public static Maybe<T> operator |(Maybe<T> self, Maybe<T> other)

--- a/Application/iSynaptic.Commons/Maybe.cs
+++ b/Application/iSynaptic.Commons/Maybe.cs
@@ -207,6 +207,11 @@ namespace iSynaptic.Commons
     	{
 			throw new NotImplementedException();
     	}
+
+		public static implicit operator bool(Maybe<T> value)
+		{
+			return value.HasValue;
+		}
     }
 
     public static class Maybe

--- a/Testing/iSynaptic.Commons.UnitTests/MaybeTests.cs
+++ b/Testing/iSynaptic.Commons.UnitTests/MaybeTests.cs
@@ -1280,6 +1280,16 @@ namespace iSynaptic.Commons
 				Assert.Fail();
 		}
 
+		[Test]
+		public void BoolOperators_NullMabesAreFalse()
+		{
+			var item = Maybe<int>.NoValue;
+			if(!item)
+				Assert.Pass();
+			else
+				Assert.Fail();
+		}
+
         public class Base{}
         public class Derived : Base{}
     }

--- a/Testing/iSynaptic.Commons.UnitTests/MaybeTests.cs
+++ b/Testing/iSynaptic.Commons.UnitTests/MaybeTests.cs
@@ -1270,6 +1270,16 @@ namespace iSynaptic.Commons
             Assert.AreEqual(42, result.Value);
         }
 
+		[Test]
+		public void BoolOperators_NonNullMabesAreTrue()
+		{
+			Maybe<int> item = 7.ToMaybe();
+			if(item)
+				Assert.Pass();
+			else
+				Assert.Fail();
+		}
+
         public class Base{}
         public class Derived : Base{}
     }

--- a/Testing/iSynaptic.Commons.UnitTests/MaybeTests.cs
+++ b/Testing/iSynaptic.Commons.UnitTests/MaybeTests.cs
@@ -1312,6 +1312,20 @@ namespace iSynaptic.Commons
 			Assert.That(item.Value, Is.EqualTo(7));
 		}
 
+		[Test]
+		public void BoolOperators_7OrNone_7()
+		{
+			Assert.That(7.ToMaybe() | Maybe.NoValue, Is.EqualTo(7.ToMaybe()));
+			Assert.That(7.ToMaybe() || Maybe.NoValue, Is.EqualTo(7.ToMaybe()));
+		}
+
+		[Test]
+		public void BoolOperators_NoneOr7_7()
+		{
+			Assert.That(Maybe.NoValue | 7.ToMaybe(), Is.EqualTo(7.ToMaybe()));
+			Assert.That(Maybe.NoValue || 7.ToMaybe(), Is.EqualTo(7.ToMaybe()));
+		}
+
         public class Base{}
         public class Derived : Base{}
     }

--- a/Testing/iSynaptic.Commons.UnitTests/MaybeTests.cs
+++ b/Testing/iSynaptic.Commons.UnitTests/MaybeTests.cs
@@ -1289,10 +1289,26 @@ namespace iSynaptic.Commons
 		}
 
 		[Test]
+		public void BoolOperators_InitializationFromDefaultTo7Is7()
+		{
+			var item = default(Maybe<int>);
+			item |= 7.ToMaybe();
+			Assert.That(item.Value, Is.EqualTo(7));
+		}
+
+		[Test]
 		public void BoolOperators_InitializationFromNoneTo7Is7()
 		{
 			Maybe<int> item = Maybe.NoValue;
 			item |= 7.ToMaybe();
+			Assert.That(item.Value, Is.EqualTo(7));
+		}
+
+		[Test]
+		public void BoolOperators_InitializationFrom7ToNoneIs7()
+		{
+			var item = 7.ToMaybe();
+			item |= Maybe<int>.NoValue;
 			Assert.That(item.Value, Is.EqualTo(7));
 		}
 

--- a/Testing/iSynaptic.Commons.UnitTests/MaybeTests.cs
+++ b/Testing/iSynaptic.Commons.UnitTests/MaybeTests.cs
@@ -1284,10 +1284,16 @@ namespace iSynaptic.Commons
 		public void BoolOperators_NullMabesAreFalse()
 		{
 			var item = Maybe<int>.NoValue;
-			if(!item)
-				Assert.Pass();
-			else
+			if(item)
 				Assert.Fail();
+		}
+
+		[Test]
+		public void BoolOperators_InitializationFromNoneTo7Is7()
+		{
+			Maybe<int> item = Maybe.NoValue;
+			item |= 7.ToMaybe();
+			Assert.That(item.Value, Is.EqualTo(7));
 		}
 
         public class Base{}


### PR DESCRIPTION
I added `true` & `|` operators for `Maybe<T>` which gives `Maybe.NoValue` a meaning that feels more like `None` in python or `nil` in ruby (more like nil than None). Now you can borrow ruby's initialization syntax:

``` csharp
private Maybe<int> theAnswer;
private void DoSomething() 
{
    // Initialize theAnswer to 42, if it doesn't already have a value
    theAnswer |= 42;
}
```

likewise, you can also use `||` for null coersion now:

``` csharp
list.Select(x => x || 0);
```

I'm aware this is already available through other iSynaptic facilities, but this gives it a very fluent syntax and makes C# start to feel even more like those scripting languages you've used.
